### PR TITLE
Introduce a watchdog thread to handle termination gracefully

### DIFF
--- a/bin/watchdog.ml
+++ b/bin/watchdog.ml
@@ -1,0 +1,16 @@
+(* When set to true, all reading threads should stop. *)
+let terminate = Atomic.make false
+
+(*
+  The watchdog will periodically check that the child process is still alive.
+  If the child process is gone, then it will set the terminate atomic variable to true.
+  Threads should be checking for this atomic variable periodically, and shut down gracefully.
+  Note: It is also possible that the terminate variable is set by a signal handler.
+*)
+let rec watchdog_func child_alive () =
+  Unix.sleepf 0.1;
+  match Atomic.get terminate with
+  | true -> ()
+  | false ->
+      if not (child_alive ()) then Atomic.set terminate true
+      else watchdog_func child_alive () 


### PR DESCRIPTION
This addresses issue #2 as well.

The source of the segfault was that, on `ctrl-c`, we would often find ourselves in situations where we can close the `Midi.device` twice. (once in the signal handler, once at the termination of the main thread, that is also calling `Midi.shutdown`.)

Another source of segfault was having the sequencer thread in `stat_engine` write to a device that was closed by said signal handler.

I also noticed that the `stat_engine` would not check the `child_alive` function to see if the instrumented program was still running or not, leading to `cardio-crumble` running indefinitely trying to poll events that would never show up.

I decided to implement a solution to all of these problems by adding a watchdog thread to be run alongside any threads the engine is using.

The idea being it is that it would introduce a `Watchdog.terminate` atomic variable, that each thread should check from time to time. If `Watchdog.terminate` is `true`, then said threads should be exiting gracefully.

The `watchdog` domain itself is just checking that `child_alive` is `false` (meaning the instrumented program has stopped).

If it detects it is the case, it will then set `terminate` to `true`, and exit.

This may be an overkill solution, but I think it works quite nicely, let me know if you have any nicer idea. :-) 