### PR TITLE
NOISSUE - Update dune-project dependencies

### DIFF
--- a/cardio_crumble.opam
+++ b/cardio_crumble.opam
@@ -11,10 +11,9 @@ doc: "https://url/to/documentation"
 bug-reports: "https://github.com/username/reponame/issues"
 depends: [
   "ocaml" {>= "5.0.0"}
-  "dune" {>= "3.3" & >= "3.7.0"}
-  "portmidi" {= "0.1"}
-  "cmdliner" {= "1.1.1"}
-  "ocamlformat" {>= "0.24.1"}
+  "dune" {>= "3.3"}
+  "portmidi" {>= "0.1"}
+  "cmdliner" {>= "1.1.1"}
   "odoc" {with-doc}
 ]
 build: [

--- a/cardio_crumble.opam
+++ b/cardio_crumble.opam
@@ -10,10 +10,11 @@ homepage: "https://github.com/username/reponame"
 doc: "https://url/to/documentation"
 bug-reports: "https://github.com/username/reponame/issues"
 depends: [
-  "ocaml"
-  "dune" {>= "3.3"}
-  "portmidi"
-  "cmdliner"
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "3.3" & >= "3.7.0"}
+  "portmidi" {= "0.1"}
+  "cmdliner" {= "1.1.1"}
+  "ocamlformat" {>= "0.24.1"}
   "odoc" {with-doc}
 ]
 build: [

--- a/cardio_crumble.opam
+++ b/cardio_crumble.opam
@@ -12,9 +12,9 @@ bug-reports: "https://github.com/username/reponame/issues"
 depends: [
   "ocaml"
   "dune" {>= "3.3"}
-  "odoc" {with-doc}
   "portmidi"
   "cmdliner"
+  "odoc" {with-doc}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/dune-project
+++ b/dune-project
@@ -19,7 +19,18 @@
  (name cardio_crumble)
  (synopsis "A short synopsis")
  (description "A longer description")
- (depends ocaml dune portmidi cmdliner)
+ (depends 
+  (ocaml
+    (>= 5.0.0))
+  (dune
+    (>= 3.7.0))
+  (portmidi
+    (= 0.1))
+  (cmdliner
+    (= 1.1.1))
+  (ocamlformat
+    (>= 0.24.1))
+)
  (tags
   (topics "to describe" your project)))
 

--- a/dune-project
+++ b/dune-project
@@ -22,14 +22,11 @@
  (depends 
   (ocaml
     (>= 5.0.0))
-  (dune
-    (>= 3.7.0))
+  dune
   (portmidi
-    (= 0.1))
+    (>= 0.1))
   (cmdliner
-    (= 1.1.1))
-  (ocamlformat
-    (>= 0.24.1))
+    (>= 1.1.1))
 )
  (tags
   (topics "to describe" your project)))

--- a/dune-project
+++ b/dune-project
@@ -19,7 +19,7 @@
  (name cardio_crumble)
  (synopsis "A short synopsis")
  (description "A longer description")
- (depends ocaml dune)
+ (depends ocaml dune portmidi cmdliner)
  (tags
   (topics "to describe" your project)))
 


### PR DESCRIPTION
In reference to :-
https://github.com/pitag-ha/cardio-crumble/pull/7#discussion_r1140449279

The dependencies needs to be mentioned in dune-project, so that dune build works normally, and the .ocamlformat matches the dependencies used in the project.